### PR TITLE
Fix usage check

### DIFF
--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,0 +1,5 @@
+fn main() {
+    for device in ctap_hmac::get_devices().unwrap() {
+        println!("{device:?}");
+    }
+}

--- a/src/hid_linux.rs
+++ b/src/hid_linux.rs
@@ -58,10 +58,12 @@ fn path_to_device(path: &PathBuf) -> io::Result<DeviceInfo> {
         }
 
         if key & REPORT_DESCRIPTOR_KEY_MASK == USAGE {
-            if size != 2 {
-                usage = u16::from(rd[pos + 1])
-            } else {
-                usage = LittleEndian::read_u16(&rd[(pos + 1)..(pos + 1 + (size as usize))]);
+            if usage == 0 {
+                if size != 2 {
+                    usage = u16::from(rd[pos + 1])
+                } else {
+                    usage = LittleEndian::read_u16(&rd[(pos + 1)..(pos + 1 + (size as usize))]);
+                }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ static BROADCAST_CID: [u8; 4] = [0xff, 0xff, 0xff, 0xff];
 pub fn get_devices() -> FidoResult<impl Iterator<Item = hid::DeviceInfo>> {
     hid::enumerate()
         .context(FidoErrorKind::Io)
-        .map(|devices| devices.filter(|dev| dev.usage_page == 0xf1d0 && dev.usage == 0x21))
+        .map(|devices| devices.filter(|dev| dev.usage_page == 0xf1d0 && dev.usage == 0x01))
         .map_err(From::from)
 }
 


### PR DESCRIPTION
This patch fixes the usage check in the device detection:

- Instead of usage 0x21, we now check for usage 0x01 as mandated by the FIDO2 spec, § 11.2.8.1 [0].
- Instead of using the last usage value in the USB descriptor, which belongs to an endpoint and not to the device, we now use the first (non-zero) value.

The descriptor parsing could still be improved, but this should fix compatibility with all compliant FIDO2 devices.

This patch also adds a simple list example for listing the detected devices.

[0] https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#usb-discovery

----

Upstream PR: https://github.com/ArdaXi/ctap/pull/5

Context:
- https://github.com/shimunn/fido2luks/issues/51
- https://github.com/trussed-dev/usbd-ctaphid/issues/1

Tested with:
- Nitrokey 3
- Nitrokey FIDO2